### PR TITLE
Send solution js to remote server

### DIFF
--- a/upload_solution.ps1
+++ b/upload_solution.ps1
@@ -1,0 +1,47 @@
+param(
+  [string]$LocalFilePath = "solution.js",
+  [string]$UserHost = "S5582010@gblearn.com"
+)
+
+$ErrorActionPreference = 'Stop'
+
+$RemoteDir = "~/public_html/comp1235/assignments/assignment4"
+$RemoteFileName = "solution.js"
+
+if (-not (Test-Path -LiteralPath $LocalFilePath)) {
+  Write-Error "Local file not found: $LocalFilePath"
+  Write-Host "Usage: .\upload_solution.ps1 -LocalFilePath path\to\solution.js [-UserHost user@host]" -ForegroundColor Yellow
+  exit 1
+}
+
+# Common SSH options: allow password prompts and auto-accept new host keys
+$sshArgsEnsureDir = @(
+  '-o','BatchMode=no',
+  '-o','StrictHostKeyChecking=accept-new',
+  $UserHost,
+  "mkdir -p '$RemoteDir'"
+)
+
+$scpArgsUpload = @(
+  '-o','BatchMode=no',
+  '-o','StrictHostKeyChecking=accept-new',
+  '--',
+  $LocalFilePath,
+  "$UserHost:$RemoteDir/$RemoteFileName"
+)
+
+try {
+  Write-Host "Ensuring remote directory exists..." -ForegroundColor Cyan
+  & ssh @sshArgsEnsureDir
+  if ($LASTEXITCODE -ne 0) { throw "ssh mkdir failed with exit code $LASTEXITCODE" }
+
+  Write-Host "Uploading $LocalFilePath to $UserHost:$RemoteDir/$RemoteFileName ..." -ForegroundColor Cyan
+  & scp @scpArgsUpload
+  if ($LASTEXITCODE -ne 0) { throw "scp upload failed with exit code $LASTEXITCODE" }
+
+  Write-Host "Upload complete: $UserHost:$RemoteDir/$RemoteFileName" -ForegroundColor Green
+}
+catch {
+  Write-Error $_
+  exit 1
+}

--- a/upload_solution.sh
+++ b/upload_solution.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Upload a local file to the remote assignment path as solution.js
+# Usage: ./upload_solution.sh [path/to/local/solution.js]
+
+REMOTE_USER_HOST="S5582010@gblearn.com"
+REMOTE_DIR="~/public_html/comp1235/assignments/assignment4"
+REMOTE_FILE_NAME="solution.js"
+
+LOCAL_FILE_PATH="${1:-solution.js}"
+
+if [[ ! -f "${LOCAL_FILE_PATH}" ]]; then
+  echo "Local file not found: ${LOCAL_FILE_PATH}" >&2
+  echo "Usage: $0 [path/to/local/solution.js]" >&2
+  exit 1
+fi
+
+# SSH options:
+# - BatchMode=yes: fail rather than prompt for passwords (non-interactive)
+# - StrictHostKeyChecking=accept-new: auto-accept new hosts, but fail on key changes
+SSH_OPTS="-o BatchMode=yes -o StrictHostKeyChecking=accept-new"
+
+# Ensure the remote directory exists
+ssh ${SSH_OPTS} "${REMOTE_USER_HOST}" "mkdir -p '${REMOTE_DIR}'"
+
+# Upload the file, forcing the remote name to solution.js
+scp ${SSH_OPTS} "${LOCAL_FILE_PATH}" "${REMOTE_USER_HOST}:${REMOTE_DIR}/${REMOTE_FILE_NAME}"
+
+echo "Upload complete: ${REMOTE_USER_HOST}:${REMOTE_DIR}/${REMOTE_FILE_NAME}"


### PR DESCRIPTION
Add `upload_solution.sh` script to upload a local file to a remote server via SCP.

---
<a href="https://cursor.com/background-agent?bcId=bc-eab74f16-55c9-43a4-8f67-a2c9530b951f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eab74f16-55c9-43a4-8f67-a2c9530b951f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

